### PR TITLE
Update git-commit-gpt to v0.2.1

### DIFF
--- a/git-commit-gpt.rb
+++ b/git-commit-gpt.rb
@@ -1,8 +1,8 @@
 class GitCommitGpt < Formula
 	desc "A tool for creating better Git commit messages using OpenAI's GPT"
 	homepage "https://github.com/jackbackes/happycommit"
-	url "https://github.com/jackbackes/happycommit/archive/refs/tags/v0.2.0.tar.gz"
-	sha256 "74d80c5254194a758d110e128c7e1fce715e5668c7de6d2b94cd4e7714fd3a19"
+	url "https://github.com/jackbackes/happycommit/archive/refs/tags/v0.2.1.tar.gz"
+	sha256 "d5558cd419c8d46bdc958064cb97f963d1ea793866414c025906ec15033512ed"
 	license "Apache-2.0"
   
 	depends_on "rust" => :build

--- a/justfile
+++ b/justfile
@@ -1,0 +1,26 @@
+# Justfile for homebrew-git-commit-gpt
+
+# command to update with version number.
+# should take a version, get the tarball from github, and update the sha256
+# should update url and sha256 in the formula
+# class GitCommitGpt < Formula
+# desc "A tool for creating better Git commit messages using OpenAI's GPT"
+# homepage "https://github.com/jackbackes/happycommit"
+# url "https://github.com/jackbackes/happycommit/archive/refs/tags/v0.2.1.tar.gz" <- update this
+# sha256 "10fe25701377af42f3cfba32c3fb7040393ef42616d5f10d899c8a57ea5d5424" <- update this
+# license "Apache-2.0"
+
+# Update the Version
+update version:
+	@echo "Updating version to $(version)"
+	# Use sed to update the url in the formula
+	@sed -i '' 's/https:\/\/github.com\/jackbackes\/happycommit\/archive\/refs\/tags\/v[0-9]\.[0-9]\.[0-9].tar.gz/https:\/\/github.com\/jackbackes\/happycommit\/archive\/refs\/tags\/v{{version}}.tar.gz/g' git-commit-gpt.rb
+	# Use sed along with $(just get_sha256 version) to update the sha256 in the formula
+	@sed -i '' 's/[0-9a-f]\{64\}/'"$(just get_sha256 {{version}})"'/g' git-commit-gpt.rb
+	echo "Done!"
+
+get_url version:
+	@echo "https://github.com/jackbackes/happycommit/archive/refs/tags/v{{version}}.tar.gz"
+
+get_sha256 version:
+	@echo `curl -L $(just get_url version) | shasum -a 256 | cut -d " " -f 1`


### PR DESCRIPTION
    This update changes the version of git-commit-gpt to v0.2.1
- Updated homebrew formula in git-commit-gpt.rb
- Formula's sha256 has been updated
- New justfile added which contains a command to update git-commit-gpt to a specific version number
- The command uses curl to calculate the sha256

    ~~~~~~~~~~
    This commit message was generated by HappyCommit. Try it in your project today!
    Check it out at https://github.com/jackbackes/happycommit